### PR TITLE
ユーザー情報編集を行った際に変更内容がヘッダーに即時反映されるようにした

### DIFF
--- a/public/script/header.js
+++ b/public/script/header.js
@@ -48,7 +48,7 @@ function displayUser(displayName, email, icon) {
 /**
  * Firestore からログイン中のユーザー情報を取得して表示する関数
  */
-async function loadAndDisplayUserInfo() {
+export async function loadAndDisplayUserInfo() {
   // 現在ログイン中のユーザー情報を取得
   const currentUser = getCurrentUser();
 

--- a/public/script/userDataEditModal.js
+++ b/public/script/userDataEditModal.js
@@ -1,5 +1,6 @@
 import AuthWrapper from "../firebase-wrapper/auth.js";
 import FirestoreWrapper from "../firebase-wrapper/firestore.js";
+import { loadAndDisplayUserInfo } from "./header.js";
 
 const auth = new AuthWrapper();
 const firestore = new FirestoreWrapper();
@@ -63,8 +64,11 @@ document.addEventListener("DOMContentLoaded", () => {
             updated: FirestoreWrapper.dateToTimestamp(new Date()),
           };
 
-          // TODO: ここでAPI送信やデータ保存処理を行う
+          // データ保存処理を行う
           await firestore.updateDocument("users", users[0].id, userData);
+
+          // 最新のユーザー情報を取得して、ヘッダーを再描画する
+          loadAndDisplayUserInfo();
 
           // モーダルを閉じる
           modalBackdrop.classList.add("hidden");


### PR DESCRIPTION
## 対応issue

#13 

## 対応内容
ユーザーのアカウント名が編集されたら、header.js の onUserChange が発火してヘッダーが再描画されることを期待していた。

```javascript

/**
 * ユーザー情報の変更を監視し、変更があれば情報を再取得・再表示する
 */
onUserChange(() => {
  // ユーザー情報を再取得して表示
  loadAndDisplayUserInfo();
});
```

しかし、よくよく考えると編集するアカウント名は Auth ではなく Firestore で保持しているので発火しようがなかった。。。
※ onUserChange は Auth の情報しか監視していないのです

アカウント名の変更を検知する仕組みを作るのもコストが高い（学生さんが読めないコードになる）ので、
シンプルに『ユーザー情報編集の処理の直後にヘッダーを再描画する処理を呼び出す』ようにしました🙇‍♂️

https://github.com/user-attachments/assets/1b64d5a5-eb64-41b8-8bb8-f2ee8bec0353


